### PR TITLE
fix: tweak workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,3 @@ updates:
     open-pull-requests-limit: 3
     labels:
       - dependencies
-      - security

--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -55,11 +55,6 @@ on:
         type: string
         description: "Choose the level of eslint to use (error, warning, info)"
         default: "error"
-      eslint-fail-on-error:
-        required: false
-        type: boolean
-        description:
-          "(DEPRECATED: use fail-level instead) To not fail the job on eslint errors set to false"
       eslint-fail-level:
         required: false
         type: string
@@ -129,8 +124,7 @@ on:
       tsc-reporter:
         required: false
         type: string
-        description:
-          "Choose the reporter to use for tsc (github-pr-review, github-pr-check, github-check)"
+        description: "Choose the reporter to use for tsc (github-pr-review, github-pr-check, github-check)"
         default: "github-check"
       tsc-level:
         required: false
@@ -145,26 +139,22 @@ on:
       # <--------------- ARTIFACT NAMING ------------->
       artifact-prefix:
         type: string
-        description:
-          "A prefix to apply to the name of the artifacts to upload (useful for matrix builds)"
+        description: "A prefix to apply to the name of the artifacts to upload (useful for matrix builds)"
         required: false
       # <--------------- GIT SETTINGS ------------->
       fetch-depth:
         required: false
         type: number
-        description:
-          "Number of commits to fetch. 0 indicates all history for all branches and tags."
+        description: "Number of commits to fetch. 0 indicates all history for all branches and tags."
         default: 1
     secrets:
       # <-------------- BUILD CREDENTIALS ---------------->
       auth-token:
         required: false
-        description:
-          "Arbitrary token to be exposed as environment variable in the format VARIABLE=value"
+        description: "Arbitrary token to be exposed as environment variable in the format VARIABLE=value"
       auth-token-2:
         required: false
-        description:
-          "Arbitrary token to be exposed as environment variable in the format VARIABLE=value"
+        description: "Arbitrary token to be exposed as environment variable in the format VARIABLE=value"
     outputs:
       ref-slug:
         description: "A URL sanitized version of the github ref"
@@ -239,7 +229,6 @@ jobs:
           reporter: ${{ inputs.eslint-reporter }}
           eslint_flags: ${{ inputs.eslint-flags }}
           level: ${{ inputs.eslint-level }}
-          fail_on_error: ${{ inputs.eslint-fail-on-error }}
           fail_level: ${{ inputs.eslint-fail-level }}
 
   # <---------------------- PRETTIER --------------------->
@@ -340,7 +329,25 @@ jobs:
             ${{ inputs.path }}/test-report.html
             ${{ inputs.path }}/coverage/test-report.html
             ${{ inputs.path }}/coverage/cobertura-coverage.xml
-
+  coverage:
+    name: Vitest coverage
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: ${{ inputs.install-command }}
+        working-directory: ${{ inputs.path }}
+      - name: Test
+        run: ${{ inputs.test-command }}
+        working-directory: ${{ inputs.path }}
+      - name: Test coverage
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          working-directory: ${{ inputs.path }}
+        continue-on-error: true
   # <----------------------- TSC ------------------------->
   tsc:
     name: TSC


### PR DESCRIPTION
This pull request includes updates to configuration files related to Dependabot and GitHub Actions workflows. The changes focus on improving maintainability by removing deprecated options, consolidating descriptions, and introducing a new job for test coverage reporting.

### Dependabot Configuration Updates:
* Removed the `security` label from Dependabot pull requests in `.github/dependabot.yml`.

### GitHub Actions Workflow Updates:
#### Removal of Deprecated Inputs:
* Removed the deprecated `eslint-fail-on-error` input from `.github/workflows/node-tests.yml` and replaced its usage with `eslint-fail-level`. [[1]](diffhunk://#diff-71ec1c1168844989b073514c56cf45ba3c8fbf8ee28b0e32e03b689111177c54L58-L62) [[2]](diffhunk://#diff-71ec1c1168844989b073514c56cf45ba3c8fbf8ee28b0e32e03b689111177c54L242)

#### Consolidation of Descriptions:
* Consolidated multi-line descriptions into single-line descriptions for several inputs, such as `tsc-reporter`, `artifact-prefix`, `fetch-depth`, and `auth-token`. This change improves readability and consistency. [[1]](diffhunk://#diff-71ec1c1168844989b073514c56cf45ba3c8fbf8ee28b0e32e03b689111177c54L132-R127) [[2]](diffhunk://#diff-71ec1c1168844989b073514c56cf45ba3c8fbf8ee28b0e32e03b689111177c54L148-R157)

#### Addition of Test Coverage Job:
* Introduced a new `coverage` job to the workflow, which uses `davelosert/vitest-coverage-report-action` to generate test coverage reports. This job runs on `ubuntu-24.04` and includes steps for checkout, Node.js setup, dependency installation, and test execution.